### PR TITLE
Markdownでブログを投稿出来るようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem 'less-rails' # Railsでlessを使えるようにする。Bootstrapがlessで
 gem 'twitter-bootstrap-rails' # Bootstrapの本体
 gem 'kaminari' #ページネーション
 gem 'jquery-turbolinks'
+gem 'redcarpet'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -42,7 +42,7 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
-    byebug (8.2.5)
+    byebug (9.0.0)
     capybara (2.7.1)
       addressable
       mime-types (>= 1.16)
@@ -159,6 +159,7 @@ GEM
     rake (11.1.2)
     rdoc (4.2.2)
       json (~> 1.4)
+    redcarpet (3.3.4)
     ref (2.0.0)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
@@ -192,7 +193,7 @@ GEM
       ref
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.2)
+    tilt (2.0.3)
     turbolinks (2.5.3)
       coffee-rails
     twitter-bootstrap-rails (3.2.2)
@@ -236,6 +237,7 @@ DEPENDENCIES
   minitest-rails-capybara (~> 2.1.1)
   mocha (~> 1.1.0)
   rails (= 4.2.0)
+  redcarpet
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   shoulda (~> 3.5.0)

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,10 @@
+module MarkdownHelper
+  def markdown(text)
+    unless @Markdown
+      renderer = Redcarpet::Render::HTML.new
+      @markdown = Redcarpet::Markdown::new(renderer)
+    end
+
+    @markdown.render(text).html_safe
+  end
+end

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,7 +2,7 @@
   <h2 class="post-title"><%= @post.title %></h2>
 
   <section class="post_info">
-      <%= escape_article(@post.text) %>
+      <%= markdown(escape_article(@post.text)) %>
   </section>
 </article>
 

--- a/test/helpers/markdown_helper_test.rb
+++ b/test/helpers/markdown_helper_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+describe MarkdownHelper do
+  before do
+    class TestHelper < ActionView::Base
+      include MarkdownHelper
+    end
+    @helper = TestHelper.new
+  end
+
+  describe "markdown_helperの動作確認" do
+    it "markdownがhtmlに変換される" do
+      assert_match "<h1>Title</h1>", @helper.markdown("#Title")
+    end
+  end
+end


### PR DESCRIPTION
### やったこと

- [x] markdownをhtmlに変換するヘルパーメソッドを実装
  - [x] ヘルパーのテスト
- [x] 記事表示時にヘルパーを呼び出してmarkdownで書かれた記事をhtmlに変換する