### PR TITLE
iphoneでheight100%がwindow.innerHeightの値になっていた問題を修正

### DIFF
--- a/app/assets/stylesheets/global.css.scss
+++ b/app/assets/stylesheets/global.css.scss
@@ -1,10 +1,5 @@
 $glay: #aaa;
 
-html,
-body {
-  height: 100%;
-}
-
 body {
   display: flex;
   min-height: 100vh;


### PR DESCRIPTION
## やったこと

フッターが以下のようにズレてしまっていたので、
CSSを修正。

![img_1427 2](https://cloud.githubusercontent.com/assets/5501268/16563084/15cb4cb8-423b-11e6-8e02-110f68a4d141.PNG)
